### PR TITLE
ci: add AOT publish smoke test (item 1 of #11)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,35 @@ jobs:
         with:
           name: test-results
           path: "**/*.trx"
+
+  aot-smoke:
+    runs-on: ubuntu-latest
+    # Publishes samples/ZeroAlloc.Collections.AotSmoke with PublishAot=true and runs
+    # the binary. Exercises HeapPooledList, HeapRingBuffer, and PooledList (ref struct).
+    # Net9.0 has full Native AOT support; the main lib multi-targets ns2.1;net8;net9
+    # so net9.0 is the highest TFM we can realistically pin the sample to without
+    # bumping the whole project to net10.0.
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
+
+      - name: Install AOT native toolchain
+        run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
+
+      - name: Restore
+        run: dotnet restore samples/ZeroAlloc.Collections.AotSmoke/ZeroAlloc.Collections.AotSmoke.csproj
+
+      - name: Publish AOT
+        run: dotnet publish samples/ZeroAlloc.Collections.AotSmoke/ZeroAlloc.Collections.AotSmoke.csproj -r linux-x64 -c Release -o ./aot-out
+
+      - name: Run AOT binary
+        run: ./aot-out/ZeroAlloc.Collections.AotSmoke

--- a/ZeroAlloc.Collections.slnx
+++ b/ZeroAlloc.Collections.slnx
@@ -3,6 +3,9 @@
     <Project Path="src/ZeroAlloc.Collections/ZeroAlloc.Collections.csproj" />
     <Project Path="src/ZeroAlloc.Collections.Generators/ZeroAlloc.Collections.Generators.csproj" />
   </Folder>
+  <Folder Name="/samples/">
+    <Project Path="samples/ZeroAlloc.Collections.AotSmoke/ZeroAlloc.Collections.AotSmoke.csproj" />
+  </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/ZeroAlloc.Collections.Tests/ZeroAlloc.Collections.Tests.csproj" />
     <Project Path="tests/ZeroAlloc.Collections.Benchmarks/ZeroAlloc.Collections.Benchmarks.csproj" />

--- a/samples/ZeroAlloc.Collections.AotSmoke/Program.cs
+++ b/samples/ZeroAlloc.Collections.AotSmoke/Program.cs
@@ -1,0 +1,41 @@
+using System;
+using ZeroAlloc.Collections;
+
+// Exercise representative heap classes + ref struct primitives under
+// PublishAot=true. Ref structs stay scoped to Main — they can't escape into
+// async / closures, so we use them directly.
+
+// 1. HeapPooledList<T>: growth across the initial capacity boundary
+using var list = new HeapPooledList<int>(capacity: 2);
+for (var i = 0; i < 10; i++) list.Add(i);
+if (list.Count != 10) return Fail($"HeapPooledList.Count expected 10, got {list.Count}");
+if (list[9] != 9) return Fail($"HeapPooledList[9] expected 9, got {list[9]}");
+list.RemoveAt(5);
+if (list.Count != 9 || list[5] != 6)
+    return Fail($"HeapPooledList.RemoveAt broke: Count={list.Count}, [5]={list[5]}");
+
+// 2. HeapRingBuffer<T>: wrap-around semantics
+using var ring = new HeapRingBuffer<int>(capacity: 3);
+if (!ring.TryWrite(1) || !ring.TryWrite(2) || !ring.TryWrite(3))
+    return Fail("HeapRingBuffer.TryWrite rejected writes within capacity");
+if (ring.TryWrite(4)) return Fail("HeapRingBuffer.TryWrite should have refused over capacity");
+if (!ring.TryRead(out var r) || r != 1) return Fail($"HeapRingBuffer.TryRead expected 1, got {r}");
+if (!ring.TryWrite(4)) return Fail("HeapRingBuffer.TryWrite should accept after a read");
+if (!ring.TryPeek(out var p) || p != 2) return Fail($"HeapRingBuffer.TryPeek expected 2, got {p}");
+
+// 3. PooledList<T> (ref struct): exercised in-scope since it cannot escape
+{
+    using var pooled = new PooledList<int>(capacity: 4);
+    for (var i = 0; i < 5; i++) pooled.Add(i * 10);
+    if (pooled.Count != 5) return Fail($"PooledList.Count expected 5, got {pooled.Count}");
+    if (pooled[4] != 40) return Fail($"PooledList[4] expected 40, got {pooled[4]}");
+}
+
+Console.WriteLine("AOT smoke: PASS");
+return 0;
+
+static int Fail(string message)
+{
+    Console.Error.WriteLine($"AOT smoke: FAIL — {message}");
+    return 1;
+}

--- a/samples/ZeroAlloc.Collections.AotSmoke/ZeroAlloc.Collections.AotSmoke.csproj
+++ b/samples/ZeroAlloc.Collections.AotSmoke/ZeroAlloc.Collections.AotSmoke.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <!-- net9.0 is the highest runtime TFM the main lib ships (ns2.1;net8.0;net9.0).
+         Native AOT is fully supported on net9.0, so net10.0 would gain nothing here
+         and force a project-wide TFM bump. -->
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <PublishAot>true</PublishAot>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <OptimizationPreference>Size</OptimizationPreference>
+
+    <!-- Per-call codes promoted to errors. Assembly-level IL2104/IL3053 stay
+         warnings (third-party roll-ups we can't fix from here). -->
+    <WarningsAsErrors>$(WarningsAsErrors);IL2026;IL2067;IL2075;IL2091;IL3050;IL3051</WarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ZeroAlloc.Collections\ZeroAlloc.Collections.csproj"
+                      SetTargetFramework="TargetFramework=net9.0" />
+    <ProjectReference Include="..\..\src\ZeroAlloc.Collections.Generators\ZeroAlloc.Collections.Generators.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false"
+                      UndefineProperties="PublishAot" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
First checklist item of #11. Exercises HeapPooledList, HeapRingBuffer, and PooledList (ref struct) under `PublishAot=true`. CI publishes + runs, failing on per-call IL warnings or non-zero exit.