### PR TITLE
chore(release): promote ZeroAlloc.Collections to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.0
+
+Stability milestone — public API of `ZeroAlloc.Collections` is now considered stable. No code changes from 0.1.6; this release marks the transition out of pre-1.0 SemVer.
+
 ## [0.1.7](https://github.com/ZeroAlloc-Net/ZeroAlloc.Collections/compare/v0.1.6...v0.1.7) (2026-04-28)
 
 


### PR DESCRIPTION
## Summary
Promote the package to the 1.0 stability milestone. No code changes — the public API is the same as 0.1.6.

This is part of an ecosystem-wide campaign promoting all sub-1.0 ZeroAlloc packages to 1.0.0 now that the integration matrix is complete.

## Mechanism
The merge commit footer `Release-As: 1.0.0` instructs release-please to release as 1.0.0 instead of its default bump. Once this PR merges, release-please opens a release PR for 1.0.0; merging that publishes 1.0.0 to NuGet.

Release-As: 1.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)