### PR TITLE
fix(release-please): drop pre-major flags (package is post-1.0)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,8 +2,6 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary

Remove `bump-minor-pre-major` and `bump-patch-for-minor-pre-major` from `release-please-config.json`. These flags only affect 0.x versioning and ZeroAlloc.Collections is at 1.1.0, so they are silent no-ops today and a SemVer hazard if the package were ever reset to 0.x.

This is the Pattern C fix from the cross-repo release-please audit.

## Out of scope

Pattern D (missing `.github/workflows/release-please.yml`) is also present on this repo but is a separate concern and will be addressed in its own PR.

## Test plan

- [ ] Confirm `release-please-config.json` is still valid JSON
- [ ] Confirm next release-please run produces the expected version bump for 1.x conventional commits (no behavior change expected since flags were already no-ops at 1.1.0)