### PR TITLE
ci: add missing release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,67 @@
+name: Release Please
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+      version: ${{ steps.release.outputs.version }}
+    steps:
+      - name: Release Please
+        uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          # Manifest mode: read release-please-config.json + .release-please-manifest.json
+          # from the repo root. Single-package mode (release-type passed inline) ignores
+          # those files and tracks state via PR labels — which can get into a corrupted
+          # state producing wrong version PRs. Mirrors ZeroAlloc.Mediator (post-PR-#65).
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            9.0.x
+
+      - name: Restore
+        run: dotnet restore ZeroAlloc.Collections.slnx
+
+      - name: Build
+        run: dotnet build ZeroAlloc.Collections.slnx --configuration Release --no-restore -p:Version=${{ needs.release-please.outputs.version }}
+
+      - name: Test
+        run: dotnet test ZeroAlloc.Collections.slnx --configuration Release --no-build --verbosity normal
+
+      - name: Pack
+        run: |
+          dotnet pack src/ZeroAlloc.Collections/ZeroAlloc.Collections.csproj -c Release --no-build -p:PackageVersion=${{ needs.release-please.outputs.version }} -o ./nupkg
+
+      - name: Push to NuGet
+        run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+      - name: Upload to GitHub Release
+        run: gh release upload ${{ needs.release-please.outputs.tag_name }} ./nupkg/*.nupkg
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Collections had `release-please-config.json` and `.release-please-manifest.json` but no workflow to actually run release-please. No release PRs ever opened, so the repo couldn't ship to NuGet via the release-please path.

This adds `.github/workflows/release-please.yml` mirroring the family standard (ZeroAlloc.Mediator post-PR-#68):

- Triggers: `push` to main + `workflow_dispatch`
- `release-please` job: `googleapis/release-please-action@v4` in manifest mode (`config-file` + `manifest-file`)
- `publish` job (gated on `release_created`): restore -> build -> test -> pack -> push to NuGet (`--skip-duplicate`) -> upload to GitHub Release

## Adaptations from Mediator template

- Single publishable package: only `src/ZeroAlloc.Collections/ZeroAlloc.Collections.csproj` is packed (the `Generators` project has `IsPackable=false` and ships bundled inside the main package's `analyzers/dotnet/cs` folder)
- .NET versions match Collections' `ci.yml`: `8.0.x` + `9.0.x` (Mediator uses `10.0.x`)
- Uses `actions/checkout@v4` and `actions/setup-dotnet@v4` to match Collections' `ci.yml` (Mediator uses v6/v5)
- Restore/build/test target the `ZeroAlloc.Collections.slnx` solution file like Collections' `ci.yml`

## Manifest

`.release-please-manifest.json` was already at `1.1.0` (matches latest stable on NuGet) — no update needed.

## Test plan

- [ ] After merge, verify a release-please PR opens automatically (or via `workflow_dispatch`)
- [ ] On merging that release PR, verify `publish` job runs, `dotnet pack` produces `ZeroAlloc.Collections.<version>.nupkg`, and it uploads to NuGet + GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)